### PR TITLE
JS/TS language processor updates

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,6 @@
 
+import * as path from "path";
+
 import * as ts from "typescript";
 import { SymbolKind, Range, Position} from 'vscode-languageserver';
 
@@ -20,5 +22,19 @@ export function formEmptyKind(): number {
 
 export function formExternalUri(external) {
     return external.repoName + "$" + external.repoURL + "$" + external.repoCommit + "$" + external.path;
-
 }
+
+/**
+ * Makes documentation string from symbol display part array returned by TS
+ */
+export function docstring(parts: ts.SymbolDisplayPart[]): string {
+    return ts.displayPartsToString(parts);
+}
+
+/**
+ * Normalizes path to match POSIX standard (slashes)
+ */
+export function normalizePath(file: string): string {
+    return file.replace(new RegExp('\\' + path.sep, 'g'), path.posix.sep);
+}
+


### PR DESCRIPTION
- dealing with different file separators
- when searching for package.json files, ignoring unreadable ones
- fixed workspace configuration in synchronous mode
- when error occurred, dumping stack
- synchronized `hover` and `exported-symbols` API endpoints to reflect API changes
- using relative path in `definition` and `local-refs` responses
- lazy objects initialization: shouldn't check if array's length is zero, it's expected to have zero items
- using map to match file to package instead of linear search
- exported refs: removed useless fields
