### PR TITLE
Fixes sourcegraph/sourcegraph#866

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -150,7 +150,10 @@ program
 
 const lspPort = program.lsp || defaultLspPort;
 const lpPort = program.lp || defaultLpPort;
-const workspace = program.workspace || path.join(process.env.SGPATH || os.tmpdir(), 'workspace', 'js');
+const workspace = program.workspace || 
+	path.join(process.env.SGPATH || path.join(os.homedir(), '.sourcegraph'), 
+		'workspace', 
+		'js');
 
 console.log('Using workspace', workspace);
 console.log('Listening for incoming LSP connections on', lspPort, 'and incoming LP connections on', lpPort);


### PR DESCRIPTION
- when no `SGPATH` is set, using `~/.sourcegraph`
