### PR TITLE
xlang support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ To try it in [Visual Studio Code](https://code.visualstudio.com), install the [v
 
 Run `node_modules/.bin/tsc --watch`.
 
+## Command line arguments 
+
+* `-p, --port` specifies port to use, default one is `2089`
+* `-s, --strict` enables strict mode where server expects all files to be receives in `didOpen` notification requests.
+
 ## Known issues
 
 * You need to disable VSCode's built-in TypeScript support to avoid weird conflicts on TypeScript files (double hover tooltips, etc.). There's a hacky way to do this: add the setting `{"typescript.tsdk": "/dev/null"}` to your VSCode user or workspace settings.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# JavaScript/TypeScript language server
+
+This is a language server for JavaScript and TypeScript that adheres to the [Language Server Protocol (LSP)](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md). It uses [TypeScript's](http://www.typescriptlang.org/) LanguageService to perform source code analysis.
+
+## Getting started
+
+1. `npm install`
+1. `node_modules/.bin/tsc`
+1. `node build/language-server.js`
+
+To try it in [Visual Studio Code](https://code.visualstudio.com), install the [vscode-client](https://github.com/sourcegraph/langserver/tree/master/vscode-client) extension and then open up a `.ts` file.
+
+## Development
+
+Run `node_modules/.bin/tsc --watch`.
+
+## Known issues
+
+* You need to disable VSCode's built-in TypeScript support to avoid weird conflicts on TypeScript files (double hover tooltips, etc.). There's a hacky way to do this: add the setting `{"typescript.tsdk": "/dev/null"}` to your VSCode user or workspace settings.
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "read-json-sync": "^1.1.1",
     "typescript": "^1.8.2",
     "vscode-languageserver": "^2.2.1",
+    "vscode-languageserver-types": "^1.0.3",
     "sanitize-html": "^1.13.0",
     "jsonpath-plus": "^0.15.0"
   }

--- a/src/external-refs-provider.ts
+++ b/src/external-refs-provider.ts
@@ -183,13 +183,13 @@ export default class ExternalRefsProvider {
         function collectImportedCalls(node: ts.Node) {
             if (node.kind == ts.SyntaxKind.PropertyAccessExpression) {
                 var ids = [];
-                ts.forEachChild(node, collectIds);
-                function collectIds(node: ts.Node) {
+				let collectIds = (node: ts.Node): void => {
                     if (node.kind == ts.SyntaxKind.Identifier) {
                         ids.push(node);
                     }
                     ts.forEachChild(node, collectIds);
                 }
+                ts.forEachChild(node, collectIds);
 
                 let idsRes = ids.map((id, index) => {
                     let pos = id.end - id.text.length;

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -18,6 +18,10 @@ import {
     SymbolInformation, SymbolKind, Range, RequestType
 } from 'vscode-languageserver';
 
+import {
+	TextDocumentChangeEvent,
+} from 'vscode-languageserver-types';
+
 import TypeScriptService from './typescript-service';
 import Connection from './connection';
 
@@ -76,6 +80,14 @@ var server = net.createServer(function (socket) {
         console.log('shutdown...');
 	return [];
     });
+
+	// Keep the documents store updated (upon receiving
+	// textDocument/didOpen, etc., notifs).
+	documents.listen(connection.connection);
+
+	documents.onDidOpen((e: TextDocumentChangeEvent) => {
+		console.log(`textDocument/didOpen ${e.document.uri}`);
+	});
 
     connection.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams): SymbolInformation[] => {
         try {

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -19,7 +19,7 @@ import {
 } from 'vscode-languageserver';
 
 import {
-	TextDocumentChangeEvent,
+    TextDocumentChangeEvent,
 } from 'vscode-languageserver-types';
 
 import TypeScriptService from './typescript-service';
@@ -96,14 +96,6 @@ var server = net.createServer(function (socket) {
             connection.service.removeFile(relpath);
         }
     });
-
-	// Keep the documents store updated (upon receiving
-	// textDocument/didOpen, etc., notifs).
-	documents.listen(connection.connection);
-
-	documents.onDidOpen((e: TextDocumentChangeEvent) => {
-		console.log(`textDocument/didOpen ${e.document.uri}`);
-	});
 
     connection.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams): SymbolInformation[] => {
         try {

--- a/src/language-service-host.ts
+++ b/src/language-service-host.ts
@@ -1,0 +1,129 @@
+/// <reference path="../typings/node/node.d.ts"/>
+///// <reference path="../typings/typescript/typescript.d.ts"/>
+import * as path from 'path';
+import * as fs from 'fs';
+
+import * as ts from 'typescript';
+
+/**
+ * Script entry, allows to keep content in memory
+ */
+class ScriptEntry {
+    content: string;
+    version: number;
+
+    constructor(content: string) {
+        this.content = content;
+        this.version = 0;
+    }
+
+    /**
+     * Updates script entry with new content, increments version automatically
+     */
+    update(content: string) {
+        this.content = content;
+        this.version++;
+    }
+}
+
+/**
+ * Language service host that manages versioned script entries and allows to switch between
+ * in-memory mode (managed by didOpen notifications) and FS scan mode when host scans for files
+ */
+export default class VersionedLanguageServiceHost implements ts.LanguageServiceHost {
+
+    root: string;
+    strict: boolean;
+
+    entries: Map<string, ScriptEntry>;
+
+    constructor(root: string, strict: boolean) {
+        this.root = root;
+        this.strict = strict;
+        this.entries = new Map<string, ScriptEntry>();
+        if (!strict) {
+            this.getFiles(root, '');
+        }
+    }
+
+    getCompilationSettings(): ts.CompilerOptions {
+        return { module: ts.ModuleKind.CommonJS, allowNonTsExtensions: true, allowJs: true };
+    }
+
+    getScriptFileNames(): string[] {                
+        return Array.from(this.entries.keys());
+    }
+
+    getScriptVersion(fileName: string): string {
+        let entry = this.entries.get(fileName);
+        return entry ? '' + entry.version : undefined;
+    }
+
+    getScriptSnapshot(fileName: string): ts.IScriptSnapshot {
+        let entry = this.entries.get(fileName);
+        if (!entry) {
+            return undefined;
+        }
+        if (this.strict) {
+            return ts.ScriptSnapshot.fromString(entry.content);
+        }
+        const fullPath = this.resolvePath(fileName);
+        if (!fs.existsSync(fullPath)) {
+            return undefined;
+        }
+        return ts.ScriptSnapshot.fromString(fs.readFileSync(fullPath).toString());
+    }
+
+    getCurrentDirectory(): string {
+        return this.root;
+    }
+
+    getDefaultLibFileName(options: ts.CompilerOptions): string {
+        return path.join(__dirname, '../src/defs/merged.lib.d.ts');
+    }
+
+    addFile(name, content: string) {        
+        let entry = this.entries.get(name);
+        if (entry) {
+            entry.update(content);
+        } else {
+            this.entries.set(name, new ScriptEntry(content));
+        }
+    }
+
+    removeFile(name) {
+        this.entries.delete(name);
+    }
+
+    hasFile(name) {
+        return this.entries.has(name);
+    }
+
+    private resolvePath(p: string): string {
+        return path.resolve(this.root, p);
+    }    
+
+    private getFiles(root: string, prefix: string) {
+        const dir: string = path.join(root, prefix);
+        const self = this;
+        if (!fs.existsSync(dir)) {
+            return
+        }
+        if (fs.statSync(dir).isDirectory()) {
+            fs.readdirSync(dir).filter(function (name) {
+                if (name[0] == '.') {
+                    return false;
+                }
+                if (name == 'node_modules') {
+                    return false;
+                }
+                return /\.[tj]sx?$/.test(name) || fs.statSync(path.join(dir, name)).isDirectory();
+            }).forEach(function (name) {
+                self.getFiles(root, path.posix.join(prefix, name))
+            })
+        } else {
+            this.entries.set(prefix, new ScriptEntry(null));
+        }
+    }
+
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -130,6 +130,10 @@ export function uri2path(uri: string): string {
 }
 
 export function uri2reluri(uri, root: string): string {
+    return path2uri('', uri2relpath(uri, root));
+}
+
+export function uri2relpath(uri, root: string): string {
     uri = uri2path(uri);
     root = normalizePath(root);
     if (uri.startsWith(root)) {
@@ -138,6 +142,6 @@ export function uri2reluri(uri, root: string): string {
     while (uri.startsWith('/')) {
         uri = uri.substring(1);
     }
-    return path2uri('', uri);
+    return uri;    
 }
 


### PR DESCRIPTION
- in strict mode (`--strict`) language server is controlled by `didOpen`/`didClose` notifications and does not attempt to scan/read files from disk
- fix typescript 2.0 compiler error  …
- add README
