### PR TITLE
Integrating into Sourcegraph

### DIFF
--- a/bin/langserver-jsts
+++ b/bin/langserver-jsts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../build/language-server-stdio.js");

--- a/bin/langserver-jsts
+++ b/bin/langserver-jsts
@@ -1,2 +1,3 @@
-#!/usr/bin/env node
-require("../build/language-server-stdio.js");
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+node $DIR/../build/language-server-stdio.js --strict

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -39,6 +39,11 @@ export default class Connection {
     constructor(input: any, output: any, strict : boolean) {
 
         this.connection = createConnection(input, output);
+        
+        input.removeAllListeners('end');
+        input.removeAllListeners('close');
+        output.removeAllListeners('end');
+        output.removeAllListeners('close');
 
         let workspaceRoot : string;
 
@@ -71,13 +76,11 @@ export default class Connection {
             }
         });
 
-        this.connection.onNotification(ExitRequest.type, function () {
-            console.log('exit...');
+        this.connection.onNotification(ExitRequest.type, function () {            
             close();
         });
 
-        this.connection.onRequest(ShutdownRequest.type, function () {
-            console.log('shutdown...');
+        this.connection.onRequest(ShutdownRequest.type, function () {            
             return [];
         });
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -85,19 +85,15 @@ export default class Connection {
         });
 
         this.connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => {
-            if (strict) {
-                let relpath = util.uri2relpath(params.textDocument.uri, workspaceRoot);
-                console.log('add file', workspaceRoot, '/', relpath);
-                this.service.addFile(relpath, params.textDocument.text);
-            }
+            let relpath = util.uri2relpath(params.textDocument.uri, workspaceRoot);
+            console.log('add file', workspaceRoot, '/', relpath);
+            this.service.addFile(relpath, params.textDocument.text);
         });
 
         this.connection.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => {
-            if (strict) {
-                let relpath = util.uri2relpath(params.textDocument.uri, workspaceRoot);
-                console.log('remove file', workspaceRoot, '/', relpath);
-                this.service.removeFile(relpath);
-            }
+            let relpath = util.uri2relpath(params.textDocument.uri, workspaceRoot);
+            console.log('remove file', workspaceRoot, '/', relpath);
+            this.service.removeFile(relpath);
         });
 
         this.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams): SymbolInformation[] => {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -60,7 +60,7 @@ export default class Connection {
         }
 
         this.connection.onRequest(InitializeRequest.type, (params: InitializeParams): InitializeResult => {
-            console.log('initialize', params.rootPath);
+            console.error('initialize', params.rootPath);
             if (params.rootPath) {
                 workspaceRoot = util.uri2path(params.rootPath);
                 this.service = new TypeScriptService(workspaceRoot, strict);
@@ -86,19 +86,19 @@ export default class Connection {
 
         this.connection.onDidOpenTextDocument((params: DidOpenTextDocumentParams) => {
             let relpath = util.uri2relpath(params.textDocument.uri, workspaceRoot);
-            console.log('add file', workspaceRoot, '/', relpath);
+            console.error('add file', workspaceRoot, '/', relpath);
             this.service.addFile(relpath, params.textDocument.text);
         });
 
         this.connection.onDidCloseTextDocument((params: DidCloseTextDocumentParams) => {
             let relpath = util.uri2relpath(params.textDocument.uri, workspaceRoot);
-            console.log('remove file', workspaceRoot, '/', relpath);
+            console.error('remove file', workspaceRoot, '/', relpath);
             this.service.removeFile(relpath);
         });
 
         this.connection.onWorkspaceSymbol((params: WorkspaceSymbolParams): SymbolInformation[] => {
             try {
-                console.log('workspace symbols', params.query);
+                console.error('workspace symbols', params.query);
                 if (params.query == "exported") {
                     const exported = this.service.getExportedEnts();
                     if (exported) {
@@ -139,7 +139,7 @@ export default class Connection {
 
         this.connection.onDefinition((params: TextDocumentPositionParams): Definition => {
             try {
-                console.log('definition', params.textDocument.uri, params.position.line, params.position.character);
+                console.error('definition', params.textDocument.uri, params.position.line, params.position.character);
                 let reluri = util.uri2reluri(params.textDocument.uri, workspaceRoot);
                 const defs: ts.DefinitionInfo[] = this.service.getDefinition(reluri, params.position.line + 1, params.position.character + 1);
                 let result: Location[] = [];
@@ -182,7 +182,7 @@ export default class Connection {
 
         this.connection.onHover((params: TextDocumentPositionParams): Hover => {
             try {
-                console.log('hover', params.textDocument.uri, params.position.line, params.position.character);
+                console.error('hover', params.textDocument.uri, params.position.line, params.position.character);
                 let reluri = util.uri2reluri(params.textDocument.uri, workspaceRoot);
                 const quickInfo: ts.QuickInfo = this.service.getHover(reluri, params.position.line + 1, params.position.character + 1);
                 let contents = [];
@@ -230,7 +230,7 @@ export default class Connection {
 
         this.connection.onRequest(GlobalRefsRequest.type, (params: WorkspaceSymbolParams): SymbolInformation[] => {
             try {
-                console.log('global-refs', params.query);
+                console.error('global-refs', params.query);
                 const externals = this.service.getExternalRefs();
                 if (externals) {
                     let res = externals.map(external => {

--- a/src/language-server.ts
+++ b/src/language-server.ts
@@ -29,6 +29,6 @@ program
 
 const lspPort = program.port || defaultLspPort;
 
-console.log('Listening for incoming LSP connections on', lspPort);
+console.error('Listening for incoming LSP connections on', lspPort);
 
 server.listen(lspPort);

--- a/src/language-service-host.ts
+++ b/src/language-service-host.ts
@@ -64,9 +64,10 @@ export default class VersionedLanguageServiceHost implements ts.LanguageServiceH
         if (!entry) {
             return undefined;
         }
-        if (this.strict) {
+        if (this.strict || entry.content) {
             return ts.ScriptSnapshot.fromString(entry.content);
         }
+
         const fullPath = this.resolvePath(fileName);
         if (!fs.existsSync(fullPath)) {
             return undefined;


### PR DESCRIPTION
- added `bin/langserver-jsts` that runs LSP server in stdio mode with `--strict` flag
- fixes #13 
- the `strict` mode works as a guardrail... even when using the langserver with vscode, it still respects textDocument/didOpen and overlays those files on top.
- printing all log messages to stderr to avoid conflicts when output goes to stdout in stdio mode
- fixed wrong `this` context
